### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/setup_links.py
+++ b/setup_links.py
@@ -374,7 +374,7 @@ class LibyuvLinkSetup():
       elif os.path.isdir(link_path):
         actions.append(Rmtree(link_path))
       else:
-        raise LinkError('Don\'t know how to plan: %s' % link_path)
+        raise LinkError('Don\'t know how to plan: {0!s}'.format(link_path))
 
     # Create parent directories to the target link if needed.
     target_parent_dirs = os.path.dirname(link_path)

--- a/sync_chromium.py
+++ b/sync_chromium.py
@@ -124,7 +124,7 @@ def main():
     gclientfile = os.path.join(opts.chromium_dir, '.gclient')
     with open(gclientfile, 'rb') as spec:
       spec = spec.read().splitlines()
-      spec[-1] = 'cache_dir = %r' % (cache_path,)
+      spec[-1] = 'cache_dir = {0!r}'.format(cache_path)
     with open(gclientfile + '.tmp', 'wb') as f:
       f.write('\n'.join(spec))
 
@@ -143,7 +143,7 @@ def main():
   if target_os_list:
     args += ['--deps=' + target_os_list]
 
-  print 'Running "%s" in %s' % (' '.join(args), opts.chromium_dir)
+  print 'Running "{0!s}" in {1!s}'.format(' '.join(args), opts.chromium_dir)
   ret = subprocess.call(args, cwd=opts.chromium_dir, env=env)
   if ret == 0:
     with open(flag_file, 'wb') as f:

--- a/tools/valgrind-libyuv/memcheck/PRESUBMIT.py
+++ b/tools/valgrind-libyuv/memcheck/PRESUBMIT.py
@@ -67,8 +67,7 @@ def CheckChange(input_api, output_api):
         continue
       if check_for_memcheck:
         if not line.startswith('Memcheck:'):
-          errors.append('"%s" should be "Memcheck:..." in %s line %s' %
-                        (line, f.LocalPath(), line_num))
+          errors.append('"{0!s}" should be "Memcheck:..." in {1!s} line {2!s}'.format(line, f.LocalPath(), line_num))
         check_for_memcheck = False;
       if line == '{':
         skip_next_line = 'skip_suppression_name'
@@ -81,7 +80,7 @@ def CheckChange(input_api, output_api):
           line.startswith('Memcheck:') or line == '}' or
           line == '...'):
         continue
-      errors.append('"%s" is probably wrong: %s line %s' % (line, f.LocalPath(),
+      errors.append('"{0!s}" is probably wrong: {1!s} line {2!s}'.format(line, f.LocalPath(),
                                                             line_num))
   if errors:
     return [output_api.PresubmitError('\n'.join(errors))]


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:libyuv?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:libyuv?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
